### PR TITLE
fix: add the default env of Vue Cli

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,12 @@ export default function envCompatible(userOptions: UserOptions = {}): Plugin {
          */
         myDefine[`${options.mountedPath}.${key}`] = JSON.stringify(value)
       })
+      /**
+       * @see {@link https://cli.vuejs.org/guide/html-and-static-assets.html#html}
+       * add the default env of Vue Cli
+       */
       config.define = {
+        'process.env.BASE_URL': "'/'",
         ...(config.define || {}),
         ...myDefine,
       }


### PR DESCRIPTION
## Background
By default, the Vue CLI will injects the `process.env.BASE_URL`

[See code in other repo](https://github.com/vuejs/vue-cli/blob/cf1022d4c4921220277e1dc9f9745f8ae12db5b6/packages/%40vue/cli-service/lib/util/resolveClientEnv.js#L3-L10)

![image](https://user-images.githubusercontent.com/22092110/128636411-a5fcd151-e5f2-4383-9fae-3826b709837b.png)


<br>
<br>

## Problems
Environment variables are not available in the file

``` js
const addDomainImg  = src => {
  return process.env.BASE_URL + `img/${src}`
}
```


![image](https://user-images.githubusercontent.com/22092110/128637119-b843e998-5dfe-4449-9d49-e9bc4d53955a.png)


<br>
<br>



