### PR TITLE
fix: Dynamic require of "fs" is not supported. fixes #13

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,16 @@
     "@types/node": "14.14.25",
     "commitizen": "2.10.1",
     "cz-customizable": "5.2.0",
-    "dotenv": "8.2.0",
-    "dotenv-expand": "5.1.0",
     "lint-staged": "10.5.4",
     "prettier": "2.2.1",
     "tsup": "^8.0.1",
     "typescript": "4.1.3",
     "vite": "2.5.1",
     "yorkie": "2.0.0"
+  },
+  "dependencies": {
+    "dotenv": "8.2.0",
+    "dotenv-expand": "5.1.0"
   },
   "prettier": {
     "printWidth": 100,

--- a/test/import-esm.mjs
+++ b/test/import-esm.mjs
@@ -1,0 +1,3 @@
+import env from '../dist/index.mjs';
+
+env();


### PR DESCRIPTION
This commit moves dotenv and dotenv-expand into `dependencies` from `devDependencies`, which lets tsup externalize them. Therefore, in the bundled code, they will be imported using native `import`s instead of `__require`s generated by esbuild, which in turn tries to call native `require` on NodeJS, which is not supported in NodeJS when the file is treated as an ESM. The detailed cause is clear in https://github.com/evanw/esbuild/issues/1921.